### PR TITLE
Add a blacklist to forgo reloading of fonts

### DIFF
--- a/cssreloader.content.js
+++ b/cssreloader.content.js
@@ -2,6 +2,11 @@
 
     var shortcutSettings;
     
+    var blacklist = [
+        new Regexp('^https?://use\.typekit\.net\/'),
+        new Regexp('^https?://fonts\.googleapis\.com\/')
+    ];
+    
     function initialize() {
         document.addEventListener("keydown", onWindowKeyDown, false);
         chrome.extension.onRequest.addListener(onExtensionRequest);
@@ -11,8 +16,15 @@
     function reload() {
         var elements = document.querySelectorAll('link[rel=stylesheet][href]');
         for (var i = 0, element; element = elements[i]; i++) {
+            if (isBlacklisted(element.href)) continue;
             var href = element.href.replace(/[?&]cssReloader=([^&$]*)/,'');
             element.href = href + (href.indexOf('?')>=0?'&':'?') + 'cssReloader=' + (new Date().valueOf());
+        }
+    }
+    
+    function isBlacklisted(href) {
+        for (var i = 0, len = blacklist.length; i < len; i++) {
+            if (blacklist[i].test(href)) return true;
         }
     }
 


### PR DESCRIPTION
This makes it so that fonts from Google Web Fonts and Typekit don't get reloaded.

Haven't tested this yet.