### PR TITLE
Fixed Issue #16 by replacing e.keyIdentifier with e.key

### DIFF
--- a/cssreloader.background.js
+++ b/cssreloader.background.js
@@ -2,7 +2,7 @@
 
     var storageKey = "shortcutOptions";
     var defaultShortcutOptions = {
-        "key"                : 'F9',
+        "keyIdentifier"      : 'F9',
         "altKeySelected"     : false,
         "controlKeySelected" : false,
         "shiftKeySelected"   : false

--- a/cssreloader.background.js
+++ b/cssreloader.background.js
@@ -2,7 +2,7 @@
 
     var storageKey = "shortcutOptions";
     var defaultShortcutOptions = {
-        "keyIdentifier"      : 'F9',
+        "key"                : 'F9',
         "altKeySelected"     : false,
         "controlKeySelected" : false,
         "shiftKeySelected"   : false

--- a/cssreloader.content.js
+++ b/cssreloader.content.js
@@ -21,7 +21,7 @@
     }
 
     function onWindowKeyDown(e) {
-        if(e.keyIdentifier == shortcutSettings["keyIdentifier"] &&
+        if(e.key == shortcutSettings["keyIdentifier"] &&
         e.shiftKey ===  shortcutSettings["shiftKeySelected"] &&
         e.altKey === shortcutSettings["altKeySelected"] &&
         e.ctrlKey === shortcutSettings["controlKeySelected"])

--- a/cssreloader.content.js
+++ b/cssreloader.content.js
@@ -21,7 +21,7 @@
     }
 
     function onWindowKeyDown(e) {
-        if(e.key == shortcutSettings["key"] &&
+        if(e.key == shortcutSettings["keyIdentifier"] &&
         e.shiftKey ===  shortcutSettings["shiftKeySelected"] &&
         e.altKey === shortcutSettings["altKeySelected"] &&
         e.ctrlKey === shortcutSettings["controlKeySelected"])

--- a/cssreloader.content.js
+++ b/cssreloader.content.js
@@ -21,7 +21,7 @@
     }
 
     function onWindowKeyDown(e) {
-        if(e.key == shortcutSettings["keyIdentifier"] &&
+        if(e.key == shortcutSettings["key"] &&
         e.shiftKey ===  shortcutSettings["shiftKeySelected"] &&
         e.altKey === shortcutSettings["altKeySelected"] &&
         e.ctrlKey === shortcutSettings["controlKeySelected"])

--- a/cssreloader.options.js
+++ b/cssreloader.options.js
@@ -71,10 +71,10 @@
         }
 
         shortcutOptions = {
-            "key" :      e.key,
-            "altKeySelected":      e.altKey,
+            "key"                : e.key,
+            "altKeySelected"     : e.altKey,
             "controlKeySelected" : e.ctrlKey,
-            "shiftKeySelected":    e.shiftKey
+            "shiftKeySelected"   : e.shiftKey
         };
 
         handleKeys(e.key, e.altKey, e.ctrlKey, e.shiftKey);

--- a/cssreloader.options.js
+++ b/cssreloader.options.js
@@ -33,7 +33,7 @@
 
         chrome.extension.sendRequest({'action' : 'getSettings'}, function(settings) {
             shortcutOptions = settings;
-            handleKeys(shortcutOptions.key, shortcutOptions.altKeySelected, shortcutOptions.controlKeySelected, shortcutOptions.shiftKeySelected);
+            handleKeys(shortcutOptions.keyIdentifier, shortcutOptions.altKeySelected, shortcutOptions.controlKeySelected, shortcutOptions.shiftKeySelected);
         });
     }
 
@@ -71,7 +71,7 @@
         }
 
         shortcutOptions = {
-            "key"                : e.key,
+            "keyIdentifier"      : e.key,
             "altKeySelected"     : e.altKey,
             "controlKeySelected" : e.ctrlKey,
             "shiftKeySelected"   : e.shiftKey

--- a/cssreloader.options.js
+++ b/cssreloader.options.js
@@ -5,9 +5,7 @@
         document.addEventListener("DOMContentLoaded", onDomReady, false);
     }
 
-    function handleKeys(keyIdentifier, isAlt, isControl, isShift) {
-        keyIdentifier = keyIdentifier;
-
+    function handleKeys(key, isAlt, isControl, isShift) {
         if (isControl) {
             addVisualKey('Ctrl');
         }
@@ -20,11 +18,11 @@
             addVisualKey('Alt');
         }
 
-        if ( (/^U+(.*)$/.test(keyIdentifier) ) ) {
-            var key = String.fromCharCode(keyIdentifier.replace('U+', '0x'));
+        if ( (/^U+(.*)$/.test(key) ) ) {
+            var key = String.fromCharCode(key.replace('U+', '0x'));
             addVisualKey(key);
         } else {
-            addVisualKey(keyIdentifier);
+            addVisualKey(key);
         }
     }
 
@@ -35,7 +33,7 @@
 
         chrome.extension.sendRequest({'action' : 'getSettings'}, function(settings) {
             shortcutOptions = settings;
-            handleKeys(shortcutOptions.keyIdentifier, shortcutOptions.altKeySelected, shortcutOptions.controlKeySelected, shortcutOptions.shiftKeySelected);
+            handleKeys(shortcutOptions.key, shortcutOptions.altKeySelected, shortcutOptions.controlKeySelected, shortcutOptions.shiftKeySelected);
         });
     }
 
@@ -73,13 +71,13 @@
         }
 
         shortcutOptions = {
-            "keyIdentifier" :      e.keyIdentifier,
+            "key" :      e.key,
             "altKeySelected":      e.altKey,
             "controlKeySelected" : e.ctrlKey,
             "shiftKeySelected":    e.shiftKey
         };
 
-        handleKeys(e.keyIdentifier, e.altKey, e.ctrlKey, e.shiftKey);
+        handleKeys(e.key, e.altKey, e.ctrlKey, e.shiftKey);
     }
 
     // Saves options to localStorage.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
 	"name": "CSS Reloader",
 	"version": "1.1.4",
-	"description": "CSS Reloader is a browser extension, that allows you to reload CSS without reloading the page itself.",
+	"description": "CSS Reloader is a browser extension which allows developers to reload CSS without reloading the page itself.",
 
   "options_page" : "options.htm",
   "background": {

--- a/readme.rdoc
+++ b/readme.rdoc
@@ -1,8 +1,8 @@
 = CSS Reloader
 
-CSS Reloader is a browser extension that allows you to reload CSS without reloading the page itself.
+CSS Reloader is a browser extension which allows developers to reload CSS without reloading the page itself.
 
-It's currently available for Mozilla Firefox and Google Chrome, 
+It's currently available for Mozilla Firefox and Google Chrome.
 
 == Usage
 


### PR DESCRIPTION
See code.
I also updated the extension manifest and readme because it looks like many non-developers attempt to use this extension as a CSS remover for a "reader"-type view. 

See reviews in Chrome store: https://chrome.google.com/webstore/detail/css-reloader/dnfpcpfijpdhabaoieccoclghgplmpbd/reviews