### PR TITLE
Added basic domain blacklist option, fixes #9

### DIFF
--- a/cssreloader.content.js
+++ b/cssreloader.content.js
@@ -13,23 +13,23 @@
         for (var i = 0, element; element = elements[i]; i++) {
             var href = element.href;
             if (!domainIsBlacklisted(getDomain(href))) {
-              var href = href.replace(/[?&]cssReloader=([^&$]*)/,'');
-              element.href = href + (href.indexOf('?')>=0?'&':'?') + 'cssReloader=' + (new Date().valueOf());
+                var href = href.replace(/[?&]cssReloader=([^&$]*)/,'');
+                element.href = href + (href.indexOf('?')>=0?'&':'?') + 'cssReloader=' + (new Date().valueOf());
             }
         }
     }
 
     function getDomain(url) {
-      return url.replace('http://','').replace('https://','').split('/')[0];
+        return url.replace('http://','').replace('https://','').split('/')[0];
     }
 
     function domainIsBlacklisted(domain) {
-      for (var i=0;i<allSettings["blacklist"].length;i++) {
-        if (allSettings["blacklist"][i] == domain) {
-          return true;
+        for (var i=0;i<allSettings["blacklist"].length;i++) {
+            if (allSettings["blacklist"][i] == domain) {
+                return true;
+            }
         }
-      }
-      return false;
+        return false;
     }
 
     function onGetSettings(settings) {

--- a/cssreloader.content.js
+++ b/cssreloader.content.js
@@ -1,6 +1,6 @@
 (function() {
 
-    var shortcutSettings;
+    var allSettings;
     
     function initialize() {
         document.addEventListener("keydown", onWindowKeyDown, false);
@@ -11,20 +11,36 @@
     function reload() {
         var elements = document.querySelectorAll('link[rel=stylesheet][href]');
         for (var i = 0, element; element = elements[i]; i++) {
-            var href = element.href.replace(/[?&]cssReloader=([^&$]*)/,'');
-            element.href = href + (href.indexOf('?')>=0?'&':'?') + 'cssReloader=' + (new Date().valueOf());
+            var href = element.href;
+            if (!domainIsBlacklisted(getDomain(href))) {
+              var href = href.replace(/[?&]cssReloader=([^&$]*)/,'');
+              element.href = href + (href.indexOf('?')>=0?'&':'?') + 'cssReloader=' + (new Date().valueOf());
+            }
         }
     }
 
+    function getDomain(url) {
+      return url.replace('http://','').replace('https://','').split('/')[0];
+    }
+
+    function domainIsBlacklisted(domain) {
+      for (var i=0;i<allSettings["blacklist"].length;i++) {
+        if (allSettings["blacklist"][i] == domain) {
+          return true;
+        }
+      }
+      return false;
+    }
+
     function onGetSettings(settings) {
-        shortcutSettings = settings;
+        allSettings = settings;
     }
 
     function onWindowKeyDown(e) {
-        if(e.key == shortcutSettings["keyIdentifier"] &&
-        e.shiftKey ===  shortcutSettings["shiftKeySelected"] &&
-        e.altKey === shortcutSettings["altKeySelected"] &&
-        e.ctrlKey === shortcutSettings["controlKeySelected"])
+        if(e.key == allSettings["keyIdentifier"] &&
+        e.shiftKey ===  allSettings["shiftKeySelected"] &&
+        e.altKey === allSettings["altKeySelected"] &&
+        e.ctrlKey === allSettings["controlKeySelected"])
         {
             reload();
         }

--- a/cssreloader.options.js
+++ b/cssreloader.options.js
@@ -1,5 +1,5 @@
 (function () {
-    var domShortcutInput, shortcutOptions;
+    var domShortcutInput, allSettings;
 
     function initialize() {
         document.addEventListener("DOMContentLoaded", onDomReady, false);
@@ -32,8 +32,9 @@
         domShortcutInput.addEventListener("focus", onShortcutFocus, false);
 
         chrome.extension.sendRequest({'action' : 'getSettings'}, function(settings) {
-            shortcutOptions = settings;
-            handleKeys(shortcutOptions.keyIdentifier, shortcutOptions.altKeySelected, shortcutOptions.controlKeySelected, shortcutOptions.shiftKeySelected);
+            allSettings = settings;
+            handleKeys(allSettings.keyIdentifier, allSettings.altKeySelected, allSettings.controlKeySelected, allSettings.shiftKeySelected);
+            document.getElementById("domain-blacklist").value = allSettings.blacklist.toString();
         });
     }
 
@@ -70,7 +71,7 @@
             }
         }
 
-        shortcutOptions = {
+        allSettings = {
             "keyIdentifier"      : e.key,
             "altKeySelected"     : e.altKey,
             "controlKeySelected" : e.ctrlKey,
@@ -80,9 +81,21 @@
         handleKeys(e.key, e.altKey, e.ctrlKey, e.shiftKey);
     }
 
+    //gets the list of domains from the textarea, formats into a proper array
+    function getBlacklistDomains() {
+      var domainElement = document.getElementById("domain-blacklist");
+      var domains = domainElement.value.trim();
+      if (domains.length > 0) {
+        domains = domains.split(",");
+      }
+
+      return domains;
+    }
+
     // Saves options to localStorage.
     function onButtonClicked() {
-        chrome.extension.sendRequest({'action' : 'saveSettings', 'data' : shortcutOptions});
+        allSettings.blacklist = getBlacklistDomains();
+        chrome.extension.sendRequest({'action' : 'saveSettings', 'data' : allSettings});
 
         // Update status to let user know options were saved.
         var status = document.querySelector('.status');

--- a/options.htm
+++ b/options.htm
@@ -35,22 +35,32 @@
 
   kbd { font-size: 20px; }
 
-  .content .shortcut {
-
+  .content .group {
     padding: 0;
     margin-bottom: 50px;
+  }
+  .group label {
+    display: block;
+    clear: both;
+  }
+  .group input,
+  .group textarea {
+    display: block;
+    clear: both;
+    padding: 5px;
+    border-radius: 10px;
+    -webkit-box-shadow: rgba(190, 190, 190, 0.699219) 0px 1px 3px inset;
+    border: 0;
+    outline: 0;
+  }
+  .content .shortcut {
     height: 60px;
     position: relative;
   }
 
   .content .shortcut input {
-    text-indent: -5000px;
-    padding: 5px;
-    border-radius: 10px;
-    -webkit-box-shadow: rgba(190, 190, 190, 0.699219) 0px 1px 3px inset;
     font-size: 20px;
-    border: 0;
-    outline: 0;
+    text-indent: -5000px;
     position: absolute;
     left: 0px;
     right: 0px;
@@ -68,7 +78,7 @@
 
 
   .content .shortcut div { display: inline-block; padding-right: 5px; }
-  .content .shortcut input:focus { -webkit-box-shadow: rgba(0, 0, 0, 1) 0px 1px 3px inset;}
+  .content .group input:focus { -webkit-box-shadow: rgba(0, 0, 0, 1) 0px 1px 3px inset;}
   .status {padding-left:20px; display: inline-block; }
 
   button {
@@ -90,11 +100,18 @@
 
   <h1>CSS Reloader</h1>
   <h2>An extension that reloads CSS.</h2>
-  <h3>Please specify the keyboard shortcut, by pressing combination in field below:</h3>
 
-  <div class="shortcut light group">
-    <input type="text" value="Press a key"/>
-    <div class="keys"></div>
+  <div class="light group">
+    <label>Please specify the keyboard shortcut, by pressing combination in field below:</label>
+    <div class="shortcut">
+      <input type="text" value="Press a key"/>
+      <div class="keys"></div>
+    </div>
+  </div>
+
+  <div class="group">
+    <label for="domain-blacklist">Blacklist one or more domain names by separating multiple domain names with commas</label>
+    <textarea name="blacklist" id="domain-blacklist" placeholder="fonts.googleapis.com,bootstrapcdn.com" style="width:455px;height:130px;"></textarea>
   </div>
 
   <button>Save settings</button>


### PR DESCRIPTION
I added a `textarea` to the extension options which accepts a comma-delimited list of domain names. This works with full domain names, not with protocols or wildcards. When a user presses the shortcut, we get the `href` attribute, remove the protocol and path using `getDomain(href)` and check it against every item in the `blacklist[]` array.

So, we can block `maxcdn.bootstrapcdn.com`, but can't block `*.bootstrapcdn.com` or `https://maxcdn.bootstrapcdn.com`. This could probably use some more thought, and possibly better explanation in the setting screen.

![css-reloader-domain-blacklist-option](https://cloud.githubusercontent.com/assets/8106227/19026697/e1610f5a-88f6-11e6-84db-4c77fc41f120.png)

Note that if we wanted to, a tiny bit of tweaking would allow the user to blacklist any urls with certain values they specify. (Instead of only testing the domain portion of the href.) Then the user could blacklist a particular css file, or any in the `bootstrap/` folder, or so on.

This is tested in Chrome. I have not tested in Firefox, I am not sure how.