### PR TITLE
Fix bug when keydown while page still loading

### DIFF
--- a/cssreloader.content.js
+++ b/cssreloader.content.js
@@ -37,6 +37,7 @@
     }
 
     function onWindowKeyDown(e) {
+        if (!allSettings) return;
         if(e.key == allSettings["keyIdentifier"] &&
         e.shiftKey ===  allSettings["shiftKeySelected"] &&
         e.altKey === allSettings["altKeySelected"] &&


### PR DESCRIPTION
While a page is still loading, there's apparently a time when `allSettings` is not yet loaded. Typing while this is happening creates the following exception:

> cssreloader.content.js:39 Uncaught TypeError: Cannot read property 'keyIdentifier' of undefined at HTMLDocument.onWindowKeyDown

If I'm pausing on exceptions (something that I think is more than an edge case for people who would use CSS Reloader), this can be really disruptive. Simply returning if `allSettings` is undefined should solve this.